### PR TITLE
make method handle final

### DIFF
--- a/src/test/java/test/MethodHandlesBenchmark.java
+++ b/src/test/java/test/MethodHandlesBenchmark.java
@@ -22,6 +22,7 @@ public class MethodHandlesBenchmark
 
     @Param({"BOUND_INVOKE", "UNBOUND_INVOKE"})
     public static String STRATEGY;
+    private final MethodHandle methodHandle;
 
     public static class Endpoint
     {
@@ -31,14 +32,19 @@ public class MethodHandlesBenchmark
         }
     }
 
+    public MethodHandlesBenchmark() {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            Method method = Endpoint.class.getMethod("onOpen", byte[].class);
+            methodHandle = lookup.unreflect(method);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Benchmark
     public void test() throws Throwable
     {
-        // Generate the base MethodHandle (we store this in a MetaData map and reuse every time).
-        MethodHandles.Lookup lookup = MethodHandles.lookup();
-        Method method = Endpoint.class.getMethod("onOpen", byte[].class);
-        MethodHandle methodHandle = lookup.unreflect(method);
-
         for (int i = 0; i < 5; i++)
         {
             // When we open a connection we bind the MethodHandle to a new Endpoint.


### PR DESCRIPTION
Please correct me if I'm wrong, but IIUC it's possible to ensure that a method handle is stored in a final variable. In this case, the results change to make these two approaches relatively equal. 

Following advice from https://stackoverflow.com/a/49303639/1542319 seems to also make the results more stable. 

```
Benchmark                        (STRATEGY)   Mode  Cnt     Score      Error  Units
MethodHandlesBenchmark.test    BOUND_INVOKE  thrpt    3  5909.462 ± 2128.965  ops/s
MethodHandlesBenchmark.test  UNBOUND_INVOKE  thrpt    3  6540.706 ± 2714.425  ops/s
```